### PR TITLE
tests: Fix get_node_count return value

### DIFF
--- a/tests/rspec/spec/meta-tests/config_file_spec.rb
+++ b/tests/rspec/spec/meta-tests/config_file_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'config_file'
+
+describe ConfigFile do
+  before(:all) do
+    @config_file = ConfigFile.new(File.join(ENV['RSPEC_PATH'], '../smoke/aws/vars/aws.basic.yaml'))
+  end
+
+  it 'returns the right node count' do
+    expect(@config_file.node_count).to eq(5)
+  end
+end


### PR DESCRIPTION
In Ruby a method returns the last evaluated
statement, if not otherwise specified via `return`.